### PR TITLE
Use TornadoFX builders for the root node as well

### DIFF
--- a/griffon-app/views/org/example/SampleView.kt
+++ b/griffon-app/views/org/example/SampleView.kt
@@ -1,23 +1,23 @@
 package org.example
 
-import griffon.core.artifact.GriffonController
 import griffon.core.artifact.GriffonView
 import griffon.inject.MVCMember
 import griffon.metadata.ArtifactProviderFor
+import javafx.event.EventDispatchChain
+import javafx.event.EventTarget
 import javafx.scene.Scene
-import javafx.scene.layout.GridPane
 import javafx.scene.paint.Color
 import javafx.stage.Stage
 import javafx.stage.Window
 import org.codehaus.griffon.runtime.javafx.artifact.AbstractJavaFXGriffonView
-import javax.annotation.Nonnull
 import tornadofx.*
+import javax.annotation.Nonnull
 
 @ArtifactProviderFor(GriffonView::class)
-class SampleView : AbstractJavaFXGriffonView() {
+class SampleView : AbstractJavaFXGriffonView(), EventTarget {
     @set:[MVCMember Nonnull]
     lateinit var model: SampleModel
-    @set:[MVCMember Nonnull]
+    @set:[MVCMember]
     lateinit var controller: SampleController
 
     override fun initUI() {
@@ -28,29 +28,31 @@ class SampleView : AbstractJavaFXGriffonView() {
     }
 
     private fun _init(): Scene {
-        val root = GridPane()
-        with(root) {
-            prefWidth  = 200.0
-            prefHeight =  60.0
+        val root = gridpane {
+            setPrefSize(200.0, 60.0)
 
             row {
-                label {
-                    bind(model.clickCountProperty())
-                }
+                label(model.clickCountProperty())
             }
+
             row {
                 button {
-                    id        = "clickActionTarget"
+                    id = "clickActionTarget"
                     prefWidth = 200.0
                 }
             }
         }
 
-        val scene: Scene = Scene(root)
-        scene.fill = Color.WHITE
+        val scene = Scene(root).apply {
+            fill = Color.WHITE
+        }
 
         connectActions(root, controller)
         connectMessageSource(root)
         return scene
     }
+
+    override fun buildEventDispatchChain(tail: EventDispatchChain?) = null
+
 }
+

--- a/griffon-app/views/org/example/SampleView.kt
+++ b/griffon-app/views/org/example/SampleView.kt
@@ -17,7 +17,7 @@ import javax.annotation.Nonnull
 class SampleView : AbstractJavaFXGriffonView(), EventTarget {
     @set:[MVCMember Nonnull]
     lateinit var model: SampleModel
-    @set:[MVCMember]
+    @set:[MVCMember Nonnull]
     lateinit var controller: SampleController
 
     override fun initUI() {
@@ -37,7 +37,7 @@ class SampleView : AbstractJavaFXGriffonView(), EventTarget {
 
             row {
                 button {
-                    id = "clickActionTarget"
+                    id        = "clickActionTarget"
                     prefWidth = 200.0
                 }
             }


### PR DESCRIPTION
I also made the code more idiomatic Kotlin / TornadoFX, including binding the Label's textProperty directly in the builder constructor.

To be able to construct the GridPane using a builder as well, the View needs to extend EventTarget, since the TornadoFX builders are registered on those. If EventTarget was added to `JavaFXGriffonView` we wouldn't have to resort to implementing `buildEventDispatchChain` in every View of course :)