### PR TITLE
Model uses IntegerProperty instead of StringProperty

### DIFF
--- a/griffon-app/controllers/org/example/SampleController.kt
+++ b/griffon-app/controllers/org/example/SampleController.kt
@@ -4,8 +4,8 @@ import griffon.core.artifact.GriffonController
 import griffon.core.controller.ControllerAction
 import griffon.inject.MVCMember
 import griffon.metadata.ArtifactProviderFor
-import org.codehaus.griffon.runtime.core.artifact.AbstractGriffonController
 import griffon.transform.Threading
+import org.codehaus.griffon.runtime.core.artifact.AbstractGriffonController
 import javax.annotation.Nonnull
 
 @ArtifactProviderFor(GriffonController::class)
@@ -16,7 +16,6 @@ class SampleController : AbstractGriffonController() {
     @ControllerAction
     @Threading(Threading.Policy.INSIDE_UITHREAD_ASYNC)
     fun click() {
-        val count = Integer.parseInt(model.clickCount)
-        model.clickCount = (count + 1).toString()
+        model.clickCount = model.clickCount + 1
     }
 }

--- a/griffon-app/models/org/example/SampleModel.kt
+++ b/griffon-app/models/org/example/SampleModel.kt
@@ -2,17 +2,14 @@ package org.example
 
 import griffon.core.artifact.GriffonModel
 import griffon.metadata.ArtifactProviderFor
-import javafx.beans.property.StringProperty
-import javafx.beans.property.SimpleStringProperty
+import javafx.beans.property.IntegerProperty
+import javafx.beans.property.SimpleIntegerProperty
 import org.codehaus.griffon.runtime.core.artifact.AbstractGriffonModel
+import tornadofx.*
 
 @ArtifactProviderFor(GriffonModel::class)
 class SampleModel : AbstractGriffonModel() {
-    private var _clickCount: StringProperty = SimpleStringProperty(this, "clickCount", "0")
-
-    var clickCount: String
-        get() = _clickCount.get()
-        set(s) = _clickCount.set(s)
-
+    private var _clickCount: IntegerProperty = SimpleIntegerProperty(this, "clickCount", 0)
+    var clickCount by _clickCount
     fun clickCountProperty() = _clickCount
 }


### PR DESCRIPTION
This avoids casting to/from String when incrementing.

This is possible because in TornadoFX, the label can be bound to any arbitrary property without having to specify a converter if toString() is fine.

I've also used TornadoFX's property delegates instead of manually creating getter/setter in the Model. This improves legibility and reduces the potential for bugs. These delegates do not rely on any TornadoFX framework integration and can be used in any JavaFX class written in Kotlin as long as `tornadofx.getValue` and `tornadofx.setValue` is imported.